### PR TITLE
Supports any built-in valid type in `_contains`

### DIFF
--- a/promptitude/library/_contains.py
+++ b/promptitude/library/_contains.py
@@ -1,36 +1,31 @@
-def contains(string: str, substring: str) -> bool:
+from typing import Any
+
+
+def contains(container: Any, item: Any) -> bool:
     """
-    Check if a string contains a substring.
+    Check if ``item`` is present in ``container``.
+
+    Now supports any built-in type that implements the ``in`` operator,
+    such as strings, lists, or dictionaries.
 
     Parameters
     ----------
-    string : str
-        The string to search within.
-    substring : str
-        The substring to search for.
+    container : Any
+        The container to search within.
+    item : Any
+        The item to search for.
 
     Returns
     -------
     result : bool
-        True if 'substring' is found within 'string', False otherwise.
+        True if ``item`` is found within ``container``, False otherwise.
 
     Raises
     ------
     TypeError
-        If 'string' or 'substring' is not a string.
-
-    Examples
-    --------
-    Use within a guidance template:
-
-    >>> from promptitude import guidance
-    >>> program = guidance("{{#if (contains val 'substr')}}contains substring{{else}}does not contain substring{{/if}}")
-    >>> output = program(val='this is a substr')
-    >>> print(output)
-    contains substring
+        If ``container`` does not support the membership test (the ``in`` operator).
     """
-    if not isinstance(string, str):
-        raise TypeError(f"'string' must be of type str, got {type(string)}.")
-    if not isinstance(substring, str):
-        raise TypeError(f"'substring' must be of type str, got {type(substring)}.")
-    return substring in string
+    if not hasattr(container, "__contains__"):
+        raise TypeError(f"'container' does not support membership test: {type(container)}")
+
+    return item in container

--- a/tests/library/test_contains.py
+++ b/tests/library/test_contains.py
@@ -9,3 +9,13 @@ def test_contains():
     assert str(program(val="no sub")) == "not equal"
     assert str(program(val="this is a substr")) == "are equal"
     assert str(program(val="this is a subsr")) == "not equal"
+
+    program_list = guidance("""{{#if (contains val 2)}}list contains 2{{else}}no 2 in list{{/if}}""")
+    assert str(program_list(val=[1, 2, 3])) == "list contains 2"
+    assert str(program_list(val=[1, 3])) == "no 2 in list"
+
+    # Test with dictionary (checking keys)
+    program_dict = guidance(
+        """{{#if (contains val "test_key")}}dict contains "test_key"{{else}}no "test_key" in dict{{/if}}""")
+    assert str(program_dict(val={"test_key": 123})) == 'dict contains "test_key"'
+    assert str(program_dict(val={"other_key": 456})) == 'no "test_key" in dict'


### PR DESCRIPTION
Now supports any built-in type that implements the ``in`` operator, such as strings, lists, or dictionaries.